### PR TITLE
Update robot battery retrieval method to handle API call errors

### DIFF
--- a/fleet_adapter_kachaka/fleet_adapter_kachaka/RobotClientAPI.py
+++ b/fleet_adapter_kachaka/fleet_adapter_kachaka/RobotClientAPI.py
@@ -214,7 +214,17 @@ class RobotAPI:
         Notes:
             - This method is not yet implemented in the robot API and always returns a placeholder value.
         """
-        return 0.8
+        url = self.prefix + "kachaka/get_battery_info"
+        try:
+            response = requests.get(url)
+            if response.status_code == 200:
+                res = response.json()['get_battery_info']
+                return res[0] / 100.0
+            else:
+                return None
+        except requests.RequestException as e:
+            print(f"Error getting robot battery: {e}")
+            return None
 
     def map(self, robot_name: str) -> str | None:
         """


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

下記に関連して、Fleet adapterもBattery情報の取得に対応する。

- ref: https://github.com/sbgisen/kachaka-api-for-openrmf/issues/8


<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!-- 変更の詳細 -->
## Detail

下記のようにバッテリー情報を取得できるようになった。
![image](https://github.com/sbgisen/fleet_adapter_kachaka/assets/20681658/d3323792-7ab5-49c2-a93d-6d177c3da6ad)

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [x] ビルドが通った
* [x] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
